### PR TITLE
Refactor GET and PATCH endpoints for document surtido.

### DIFF
--- a/OlinApiSurtido/Controllers/Controlador.cs
+++ b/OlinApiSurtido/Controllers/Controlador.cs
@@ -23,19 +23,27 @@ namespace MiApi.Controller
             return Ok(detalles);
         }
 
-        [HttpPost]
-        public async Task<IActionResult> SetDetallesDocumento([FromBody] List<SetterDocumentoDetalle> detallesSetter)
+        [HttpPatch("{documentoId}")]
+        public async Task<IActionResult> UpdateSurtidoDetalle(int documentoId, [FromBody] List<SetterSurtidos_Detalle> detallesSurtidos)
         {
-            if (detallesSetter == null || detallesSetter.Count == 0) { return BadRequest(new { message = "La lista de detalles no puede estar vacía." }); }
+            if (detallesSurtidos == null || detallesSurtidos.Count == 0)
+            {
+                return BadRequest(new { message = "La lista de detalles no puede estar vacía." });
+            }
             try
             {
-                DateTime fechaHoraActual = DateTime.Now;
-                bool updateSuccess = await repositorio.ActualizarDetallesAsync(detallesSetter, fechaHoraActual);
-                if (!updateSuccess) { return StatusCode(500, new { message = "No se pudieron actualizar todos los detalles." }); }
-                return Ok(new { message = "Detalles actualizados exitosamente.", fechaActualizacion = fechaHoraActual });
+                // The repository will now handle the logic, including the date.
+                bool updateSuccess = await repositorio.ActualizarSurtidoAsync(documentoId, detallesSurtidos);
+                if (!updateSuccess)
+                {
+                    return StatusCode(500, new { message = "No se pudieron actualizar todos los detalles." });
+                }
+                return Ok(new { message = "Detalles de surtido actualizados exitosamente." });
             }
-            catch (SqlException ex) { return StatusCode(500, new { message = $"Error de base de datos: {ex.Message}" }); }
-            catch (Exception ex) { return StatusCode(500, new { message = $"Error interno del servidor: {ex.Message}" }); }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = $"Error interno del servidor: {ex.Message}" });
+            }
         }
     }
 }

--- a/OlinApiSurtido/Data/Contexto.cs
+++ b/OlinApiSurtido/Data/Contexto.cs
@@ -11,5 +11,25 @@ namespace MiApi.Context
         public DbSet<DetalleDocumento> DetalleDocumentos { get; set; }
         public DbSet<Unidad> Unidades { get; set; }
         public DbSet<ProductoPrecio> ProductosPrecios { get; set; }
+        public DbSet<SurtidoEncabezado> SurtidosEncabezado { get; set; }
+        public DbSet<SurtidoDetalle> SurtidosDetalle { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<DetalleDocumento>()
+                .HasKey(dd => new { dd.DOCUMENTO_ID, dd.ID });
+
+            modelBuilder.Entity<ProductoPrecio>()
+                .HasKey(pp => new { pp.PRODUCTO, pp.UNIDAD_MEDIDA_EQUIVALENCIA });
+
+            modelBuilder.Entity<SurtidoDetalle>()
+                .HasKey(sd => new { sd.DOCUMENTO_ID, sd.ID });
+
+            // Define the one-to-one relationship between DetalleDocumento and SurtidoDetalle
+            modelBuilder.Entity<DetalleDocumento>()
+                .HasOne<SurtidoDetalle>()
+                .WithOne()
+                .HasForeignKey<SurtidoDetalle>(sd => new { sd.DOCUMENTO_ID, sd.ID });
+        }
     }
 }

--- a/OlinApiSurtido/Interfaces/IRepositorioDocumentoDetalle.cs
+++ b/OlinApiSurtido/Interfaces/IRepositorioDocumentoDetalle.cs
@@ -5,6 +5,6 @@ namespace MiApi.Interfaces
     public interface IRepositorioDocumentoDetalle
     {
         Task<(List<GetterDocumentoDetalle>? Detalles, bool EsSurtido, string ErrorMessage)> GetDetallesPorDocumentoIdAsync(int id);
-        Task<bool> ActualizarDetallesAsync(List<SetterDocumentoDetalle> detallesSetter, DateTime fechaHoraActual);
+        Task<bool> ActualizarSurtidoAsync(int documentoId, List<SetterSurtidos_Detalle> detallesSurtidos);
     }
 }

--- a/OlinApiSurtido/Models/Modelos.cs
+++ b/OlinApiSurtido/Models/Modelos.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace MiApi.Models
 {
+    // --- Entities ---
+
     [Table("DETALLE_DOCUMENTOS")]
-    [PrimaryKey(nameof(DOCUMENTO_ID), nameof(ID))]
     public class DetalleDocumento
     {
         public int DOCUMENTO_ID { get; set; }
@@ -13,11 +13,9 @@ namespace MiApi.Models
         public int TIPO_DOCTO { get; set; }
         public int PRODUCTO { get; set; }
         public string? DESCRIPCION { get; set; }
-        public float UNIDADES_SURTIDAS { get; set; }
         public float CANTIDAD { get; set; }
         public int UNIDAD_MEDIDA { get; set; }
         public int UNIDAD_BASE { get; set; }
-        public DateTime? FECHA_ENTREGA { get; set; }
     }
 
     [Table("UNIDADES")]
@@ -28,7 +26,6 @@ namespace MiApi.Models
     }
 
     [Table("PRODUCTOS_PRECIOS")]
-    [PrimaryKey(nameof(PRODUCTO), nameof(UNIDAD_MEDIDA_EQUIVALENCIA))]
     public class ProductoPrecio
     {
         public int PRODUCTO { get; set; }
@@ -36,24 +33,42 @@ namespace MiApi.Models
         public string? CODIGO_BARRAS { get; set; }
     }
 
+    [Table("SURTIDOS_ENCABEZADO")]
+    public class SurtidoEncabezado
+    {
+        public int ID { get; set; }
+        public bool COMPLETADO { get; set; }
+    }
+
+    [Table("SURTIDOS_DETALLE")]
+    public class SurtidoDetalle
+    {
+        public int DOCUMENTO_ID { get; set; }
+        public int ID { get; set; }
+        public float SURTIDAS { get; set; }
+        public int CHECADOR { get; set; }
+        public DateTime FIN_SURTIDO { get; set; }
+    }
+
+    // --- DTOs ---
+
+    // DTO for the GET endpoint response, matches the user's requested SELECT query
     public class GetterDocumentoDetalle
     {
-        public int DOCUMENTO_ID { get; set; }
-        public required string NUMERO_DOCUMENTO { get; set; }
-        public int TIPO_DOCTO { get; set; }
         public int ID { get; set; }
         public int PRODUCTO { get; set; }
-        public required string DESCRIPCION { get; set; }
-        public float UNIDADES_SURTIDAS { get; set; }
+        public string DESCRIPCION { get; set; } = string.Empty;
+        public float? SURTIDAS { get; set; } // Nullable because of LEFT JOIN
         public float CANTIDAD { get; set; }
-        public required string ABREVIACION { get; set; }
+        public string ABREVIACION { get; set; } = string.Empty;
         public string? CODIGO_BARRAS { get; set; }
     }
-    public class SetterDocumentoDetalle
+
+    // DTO for the PATCH endpoint request
+    public class SetterSurtidos_Detalle
     {
-        public int DOCUMENTO_ID { get; set; }
         public int ID { get; set; }
-        public float UNIDADES_SURTIDAS { get; set; }
-        public DateTime FECHA_ENTREGA { get; } = DateTime.Now;
+        public float SURTIDAS { get; set; }
+        public int CHECADOR { get; set; }
     }
 }


### PR DESCRIPTION
This commit implements significant changes to the document surtido endpoints to align with new business logic and database schema changes. The entire data access layer for this feature has been migrated from raw ADO.NET to Entity Framework Core.

- Replaced the POST endpoint with a PATCH endpoint for updating surtido details.
- Implemented "upsert" logic in the PATCH repository method to insert or update records in the new `SURTIDOS_DETALLE` table.
- Reworked the GET endpoint to first check the `SURTIDOS_ENCABEZADO` table for completion status before fetching details.
- The GET details query now joins with `SURTIDOS_DETALLE` to retrieve the correct data.
- Created all necessary EF Core entities, DTOs, and configured composite keys and relationships using the Fluent API in the DbContext.