### PR TITLE
Refactor GetDetallesPorDocumentoIdAsync to use explicit joins and add…

### DIFF
--- a/OlinApiSurtido/Models/Modelos.cs
+++ b/OlinApiSurtido/Models/Modelos.cs
@@ -63,7 +63,7 @@ namespace MiApi.Models
         public string DESCRIPCION { get; set; } = string.Empty;
         public float? SURTIDAS { get; set; } // Nullable because of LEFT JOIN
         public float CANTIDAD { get; set; }
-        public string ABREVIACION { get; set; } = string.Empty;
+        public string? ABREVIACION { get; set; } // Nullable to precisely match JOIN results
         public string? CODIGO_BARRAS { get; set; }
     }
 


### PR DESCRIPTION
… strict null validation.

- Replaced the LINQ query in `GetDetallesPorDocumentoIdAsync` to use explicit `LEFT JOIN`s, mirroring the provided SQL query for improved performance and clarity.
- Updated the `GetterDocumentoDetalle` DTO to make `ABREVIACION` nullable to support the new logic.
- Implemented a validation step that returns an error if `SURTIDAS`, `ABREVIACION`, or `CODIGO_BARRAS` are null for any detail line in a document.