### PR TITLE
fix: Add missing INICIO_SURTIDO property to SurtidoDetalle model

### DIFF
--- a/OlinApiSurtido/Models/Modelos.cs
+++ b/OlinApiSurtido/Models/Modelos.cs
@@ -48,6 +48,7 @@ namespace MiApi.Models
         public int ID { get; set; }
         public float? SURTIDAS { get; set; }
         public int? CHECADOR { get; set; }
+        public DateTime INICIO_SURTIDO { get; set; }
         public DateTime? FIN_SURTIDO { get; set; }
 
         public virtual DetalleDocumento? DetalleDocumento { get; set; }


### PR DESCRIPTION
This resolves the persistent data materialization issue. The `SurtidoDetalle` table in the database has a non-nullable `INICIO_SURTIDO` column that was missing from the C# entity model. This discrepancy caused Entity Framework Core to fail silently when materializing `SurtidoDetalle` objects, leading to incorrect null reference errors downstream.

Adding the property to the model ensures it is a complete representation of the database schema, resolving the bug.